### PR TITLE
Add Formvalidation library to the asset pipeline 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,6 @@
 
 # Ignore application configuration
 /config/application.yml
+
+# Ignore vendored gems
+/vendor/ruby

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -23,3 +23,7 @@
 //= require moment
 //= require bootstrap-datetimepicker
 //= require jquery-ui
+
+// Form Validation lib
+//= require dist/js/formValidation.min.js
+//= require dist/js/framework/bootstrap.min.js

--- a/app/assets/stylesheets/application.css.scss
+++ b/app/assets/stylesheets/application.css.scss
@@ -12,6 +12,9 @@
  *= require_tree .
  *= require jquery-ui
  *= require jquery-ui/autocomplete
+
+ * Form Validation Lib
+ *= dist/css/formValidation.min.css
  */
 @import "bootstrap-sprockets";
 @import "bootstrap";

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,47 +1,25 @@
 <!DOCTYPE html>
 <html>
 <head>
-	  <meta http-equiv="content-type" content="text/html; charset=UTF-8">
-    <meta charset="utf-8">
-    <title>acmeTRAVEL Engine</title>
-    <meta name="generator" content="Bootply" />
-    <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1">
+  <meta http-equiv="content-type" content="text/html; charset=UTF-8">
+  <meta charset="utf-8">
+  <title>acmeTRAVEL Engine</title>
+  <meta name="generator" content="Bootply" />
+  <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1">
 
-    <link href="/assets/bootstrap.min.css" media="all" rel="stylesheet" />
-    <link href="//netdna.bootstrapcdn.com/font-awesome/3.2.1/css/font-awesome.min.css" rel="stylesheet">
-    <!--[if lt IE 9]>
-      <script src="//html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
-    <link href="css/styles.css" rel="stylesheet">
-    <link href="css/bootstrap.css" rel="stylesheet" />
-  
+  <link href="//netdna.bootstrapcdn.com/font-awesome/3.2.1/css/font-awesome.min.css" rel="stylesheet">
+  <!--[if lt IE 9]>
+    <script src="//html5shim.googlecode.com/svn/trunk/html5.js"></script>
+  <![endif]-->
 
-    <!-- Latest compiled and minified CSS -->
-      <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.4/css/bootstrap.min.css">
+  <!-- HTML5 shim and Respond.js for IE8 support of HTML5 elements and media queries -->
+  <!-- WARNING: Respond.js doesn't work if you view the page via file:// -->
+  <!--[if lt IE 9]>
+    <script src="https://oss.maxcdn.com/html5shiv/3.7.2/html5shiv.min.js"></script>
+    <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
+  <![endif]-->
 
-      <!-- FormValidation CSS file -->
-     <!-- <link rel="stylesheet" href="/assets/formvalidation/dist/css/formValidation.min.css"> -->
-      <!-- Optional theme -->
-      <!--<link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.4/css/bootstrap-theme.min.css">-->
-
-      <!-- HTML5 shim and Respond.js for IE8 support of HTML5 elements and media queries -->
-      <!-- WARNING: Respond.js doesn't work if you view the page via file:// -->
-      <!--[if lt IE 9]>
-        <script src="https://oss.maxcdn.com/html5shiv/3.7.2/html5shiv.min.js"></script>
-        <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
-      <![endif]-->
-
-      <!-- Latest compiled and minified jQuery Core -->
-      <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.11.3/jquery.min.js"></script>
-      <script src="http://code.jquery.com/ui/1.10.2/jquery-ui.js" ></script>
-
-      <link href="http://code.jquery.com/ui/1.10.2/themes/smoothness/jquery-ui.css" rel="Stylesheet"></link>
-      
-  
-      <script src="/assets/bootstrap/js/bootstrap.min.js"></script>
-      <!-- FormValidation plugin and the class supports validating Bootstrap form -->
-      <!-- <script src="/assets/formvalidation/dist/js/formValidation.min.js"></script>
-      <script src="/assets/formvalidation/dist/js/framework/bootstrap.min.js"></script> -->
+  <link href="http://code.jquery.com/ui/1.10.2/themes/smoothness/jquery-ui.css" rel="Stylesheet"></link>
 
   <%= stylesheet_link_tag    "application", media: "all", "data-turbolinks-track" => true %>
   <%= javascript_include_tag "application", "autocomplete-rails.js", "data-turbolinks-track" => true %>
@@ -49,7 +27,7 @@
 </head>
 <body>
 
-      
+
 <%= yield %>
 
 

--- a/config/application.rb
+++ b/config/application.rb
@@ -12,7 +12,7 @@ module Acmetravel
   class Application < Rails::Application
 
     config.autoload_paths << Rails.root.join('lib')
-    # config.assets.paths << Rails.root.join('vendor','formvalidation','dist')
+    config.assets.paths << Rails.root.join('vendor','formvalidation')
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration should go into files in config/initializers
     # -- all .rb files in that directory are automatically loaded.


### PR DESCRIPTION
And clear up some of the asset errors that were occurring

There were two changes to add the formvalidation library to the asset pipeline:
1. Update application.rb to add formvalidation to the asset paths
2. Update application.js and application.css to use the correct paths to the formvalidation files.

I also cleaned up application.html.erb to remove a few of the errors that were occurring when loading assets
